### PR TITLE
implement initial tab view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,12 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# Auto-generated
+windows/flutter/generated_plugins.cmake
+windows/flutter/generated_plugin_registrant.h
+windows/flutter/generated_plugin_registrant.cc
+macos/Flutter/GeneratedPluginRegistrant.swift
+linux/flutter/generated_plugins.cmake
+linux/flutter/generated_plugin_registrant.h
+linux/flutter/generated_plugin_registrant.cc

--- a/lib/core/languages/app_localizations.dart
+++ b/lib/core/languages/app_localizations.dart
@@ -96,6 +96,36 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'알콜 프리'**
   String get title;
+
+  /// No description provided for @promise.
+  ///
+  /// In ko, this message translates to:
+  /// **'약속'**
+  String get promise;
+
+  /// No description provided for @diary.
+  ///
+  /// In ko, this message translates to:
+  /// **'일지'**
+  String get diary;
+
+  /// No description provided for @home.
+  ///
+  /// In ko, this message translates to:
+  /// **'홈'**
+  String get home;
+
+  /// No description provided for @community.
+  ///
+  /// In ko, this message translates to:
+  /// **'커뮤니티'**
+  String get community;
+
+  /// No description provided for @my.
+  ///
+  /// In ko, this message translates to:
+  /// **'마이'**
+  String get my;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/core/languages/app_localizations_ko.dart
+++ b/lib/core/languages/app_localizations_ko.dart
@@ -6,4 +6,19 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get title => '알콜 프리';
+
+  @override
+  String get promise => '약속';
+
+  @override
+  String get diary => '일지';
+
+  @override
+  String get home => '홈';
+
+  @override
+  String get community => '커뮤니티';
+
+  @override
+  String get my => '마이';
 }

--- a/lib/core/languages/l10n/app_ko.arb
+++ b/lib/core/languages/l10n/app_ko.arb
@@ -1,3 +1,8 @@
 {
-  "title": "알콜 프리"
+  "title": "알콜 프리",
+  "promise": "약속",
+  "diary": "일지",
+  "home": "홈",
+  "community": "커뮤니티",
+  "my": "마이"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,105 +31,53 @@ class MyApp extends StatelessWidget {
       supportedLocales: const [
         Locale('ko'), //Korean
       ],
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // Try running your application with "flutter run". You'll see the
-        // application has a blue toolbar. Then, without quitting the app, try
-        // changing the primarySwatch below to Colors.green and then invoke
-        // "hot reload" (press "r" in the console where you ran "flutter run",
-        // or simply save your changes to "hot reload" in a Flutter IDE).
-        // Notice that the counter didn't reset back to zero; the application
-        // is not restarted.
-        primarySwatch: Colors.blue,
-      ),
-      home: const MyHomePage(title: 'Alcohol Free'),
+      theme: ThemeData(primaryColor: Colors.white),
+      home: BottomNavigator(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+class BottomNavigator extends StatelessWidget {
+  BottomNavigator({super.key});
 
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+  final List<Widget> _widgetOptions = [
+    const Text('약속 화면'),
+    const Text('일지 화면'),
+    const Text('홈 화면'),
+    const Text('커뮤니티 화면'),
+    const Text('마이 화면'),
+  ];
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(AppLocalizations.of(context)!.title),
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+    return DefaultTabController(
+      initialIndex: 2,
+      length: 5,
+      child: Scaffold(
+        bottomNavigationBar: Container(
+          decoration: const BoxDecoration(
+              color: Colors.white,
+              border: Border(
+                  top: BorderSide(color: Color(0xffE2E2E2), width: 1.0))),
+          child: TabBar(
+            tabs: <Widget>[
+              Tab(icon: Text(AppLocalizations.of(context)!.promise)),
+              Tab(icon: Text(AppLocalizations.of(context)!.diary)),
+              Tab(icon: Text(AppLocalizations.of(context)!.home)),
+              Tab(icon: Text(AppLocalizations.of(context)!.community)),
+              Tab(icon: Text(AppLocalizations.of(context)!.my))
+            ],
+            indicatorColor: Colors.transparent,
+            unselectedLabelStyle: const TextStyle(
+                color: Color(0xffE2E2E2), fontWeight: FontWeight.normal),
+            labelStyle: const TextStyle(
+                color: Colors.black, fontWeight: FontWeight.bold),
+          ),
+        ),
+        body: TabBarView(
+          children: _widgetOptions,
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }


### PR DESCRIPTION
# 개요

* resolves #2 
* 요런 느낌

https://user-images.githubusercontent.com/88723775/222918071-4f5f4791-1177-4263-ae79-6834cfc26364.mp4



# 작업사항

* tab view로 넘어가는 부분을 코드 단계에서 완성하였습니다.
* 디자인이 완벽하게 반영된 것은 아닌데, tab view 위에 다른 화면을 더 얹을 예정이라 디자인을 정확하게 반영하는 것은 flutter 디자인 쪽을 좀더 알아보고 다시 issue 만들어서 올리겠습니다.

# 변경로직

* create new flutter app을 하는 경우 자동으로 생성되는 counter 코드를 삭제
*  BottomNavigator을 사용하여 화면 하단에 5가지 탭을 구성했으며, 스와이프로 넘길 수 있도록 TabBar를 추가적으로 이용하였습니다.
* 각각의 탭 화면이 넘어가는 것을 명시적으로 보여주기 위해 `_widgetOptions`에 일부 Text가 임시로 추가되어있습니다. 나중에 각각 탭 화면 구현한 뒤에는 삭제될 예정...
* vscode에서 작업하는 경우 `flutter run`을 하는 경우 auto generate되어 자꾸 Changes로 인식되는 파일들이 있어 gitignore에 추가하였습니다.