### PR TITLE
architecture refactored

### DIFF
--- a/lib/app/data/providers/firebase_auth_provider.dart
+++ b/lib/app/data/providers/firebase_auth_provider.dart
@@ -5,8 +5,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get/get.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
-class AuthProvider extends GetxService {
-  static AuthProvider get to => Get.find<AuthProvider>();
+class FirebaseAuthProvider extends GetxService {
+  static FirebaseAuthProvider get to => Get.find<FirebaseAuthProvider>();
 
   Future<AlcoholFreeUser?> signInWithGoogle() async {
     try {
@@ -25,8 +25,8 @@ class AuthProvider extends GetxService {
       return AlcoholFreeUser.fromUserCredential(credential);
     } catch (e) {
       log("ERROR(AuthProvider.signInWithGoogle): ${e.toString()}");
-      return null;
     }
+    return null;
   }
 
   Future<AlcoholFreeUser?> signInWithEmailAndPassword(
@@ -43,11 +43,10 @@ class AuthProvider extends GetxService {
       } else if (e.code == AuthError.WRONG_PASSWORD) {
         rethrow;
       }
-      return null;
     } catch (e) {
       log("ERROR(AuthProvider.signInWithEmailAndPassword): ${e.toString()}");
-      return null;
     }
+    return null;
   }
 
   Future<AlcoholFreeUser?> createAccount(String email, String password) async {
@@ -61,10 +60,9 @@ class AuthProvider extends GetxService {
       } else if (e.code == AuthError.WEAK_PASSWORD) {
         rethrow;
       }
-      return null;
     } catch (e) {
       log("ERROR(AuthService.createAccount): ${e.toString()}");
-      return null;
     }
+    return null;
   }
 }

--- a/lib/app/data/services/auth_service/auth_repository.dart
+++ b/lib/app/data/services/auth_service/auth_repository.dart
@@ -1,0 +1,31 @@
+import 'package:alcohol_free/app/data/models/alcohol_free_user.dart';
+import 'package:alcohol_free/app/data/providers/firebase_auth_provider.dart';
+
+class AuthRepository {
+  final FirebaseAuthProvider _firebaseAuthProvider = FirebaseAuthProvider.to;
+
+  Future<AlcoholFreeUser?> signInWithGoogle() async {
+    try {
+      return _firebaseAuthProvider.signInWithGoogle();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<AlcoholFreeUser?> signInWithEmailAndPassword(
+      String email, String password) async {
+    try {
+      return _firebaseAuthProvider.signInWithEmailAndPassword(email, password);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<AlcoholFreeUser?> createAccount(String email, String password) async {
+    try {
+      return _firebaseAuthProvider.createAccount(email, password);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/app/data/services/auth_service/auth_service.dart
+++ b/lib/app/data/services/auth_service/auth_service.dart
@@ -1,0 +1,33 @@
+import 'package:alcohol_free/app/data/models/alcohol_free_user.dart';
+import 'package:alcohol_free/app/data/services/auth_service/auth_repository.dart';
+import 'package:get/get.dart';
+
+class AuthService extends GetxService {
+  static AuthService get to => Get.find<AuthService>();
+  final AuthRepository _authRepository = AuthRepository();
+
+  Future<AlcoholFreeUser?> signInWithGoogle() async {
+    try {
+      return _authRepository.signInWithGoogle();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<AlcoholFreeUser?> signInWithEmailAndPassword(
+      String email, String password) async {
+    try {
+      return _authRepository.signInWithEmailAndPassword(email, password);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<AlcoholFreeUser?> createAccount(String email, String password) async {
+    try {
+      return _authRepository.createAccount(email, password);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/core/utils/app_initializations.dart
+++ b/lib/core/utils/app_initializations.dart
@@ -1,4 +1,5 @@
-import 'package:alcohol_free/app/data/providers/auth_provider.dart';
+import 'package:alcohol_free/app/data/providers/firebase_auth_provider.dart';
+import 'package:alcohol_free/app/data/services/auth_service/auth_service.dart';
 import 'package:alcohol_free/core/values/firebase_options.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:get/get.dart';
@@ -11,9 +12,10 @@ Future<void> initializeFirebase() async {
 
 Future<void> initializeProviders() async {
   // Provider 생성 시 추가
-  Get.put(AuthProvider());
+  Get.put(FirebaseAuthProvider());
 }
 
 Future<void> initializeServices() async {
   // Service 생성 시 추가
+  Get.put(AuthService());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:alcohol_free/app/data/providers/auth_provider.dart';
+import 'package:alcohol_free/app/data/providers/firebase_auth_provider.dart';
 import 'package:alcohol_free/core/languages/app_localizations.dart';
 import 'package:alcohol_free/core/utils/app_initializations.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
# 개요
#7
#8  
Viewmodel에서 직접 provider을 reference하여 사용하게 만드려고 했지만, 아키텍쳐 규약(Viewmodel은 service를 ref, service는 repo를 ref, repo는 provider을 ref)을 어기기에 wrapper service를 만드는게 낫다고 판단함.

이렇게 바꾸면 Viewmodel은 auth service만 reference하기에 나중에 auth provider가 바뀌어도 repository에서 바꿔주기만 하면 되기에 Viewmodel에서 수정할 코드는 없음.

백엔드 작업만 하여도 앱이 정상적으로 돌아 갈 것임.

코드의 양은 늘어났지만 유지보수성을 챙김.

# 작업사항
- AuthService, AuthRepository 생성
- AuthProvider -> FirebaseAuthProvider로 이름 변경

# 변경로직
- viewmodel은 service만 reference하면 됨 repository, provider는 신경쓸 필요 없음.
