### PR TITLE
fix compile error by referencing non-existent file

### DIFF
--- a/lib/core/utils/app_initializations.dart
+++ b/lib/core/utils/app_initializations.dart
@@ -1,4 +1,4 @@
-import 'package:alcohol_free/app/data/providers/auth_provider.dart';
+import 'package:alcohol_free/app/data/providers/firebase_auth_provider.dart';
 import 'package:alcohol_free/app/data/services/notification_service/notification_service.dart';
 import 'package:alcohol_free/app/data/services/auth_service/auth_service.dart';
 import 'package:alcohol_free/core/values/firebase_options.dart';


### PR DESCRIPTION
`auth_provider.dart`가 `firebase_auth_provider.dart`로 바뀐 것 같은데 여전히 app_initializations.dart에서 `auth_provider.dart`를 참조하고 있어서 컴파일에러가 나게 됐었습니다.
해당 부분을 고쳤습니다.